### PR TITLE
fix impactlab asset mount points

### DIFF
--- a/impactlab-config.yml
+++ b/impactlab-config.yml
@@ -70,10 +70,10 @@ jupyterhub:
         gitRepo:
           repository: "https://github.com/ClimateImpactLab/climate-impactlab-templates.git"
     extraVolumeMounts:
-      - mountPath: /usr/local/share/jupyter/hub/custom_templates
+      - mountPath: /usr/local/share/jupyterhub/custom_templates
         name: custom-templates
         subPath: "climate-impactlab-templates/templates"
-      - mountPath: /usr/local/share/jupyter/hub/static/custom
+      - mountPath: /usr/local/share/jupyterhub/static/custom
         name: custom-templates
         subPath: "climate-impactlab-templates/assets"
 


### PR DESCRIPTION
Fix assets to mount to `/usr/local/share/jupyterhub` instead of `/usr/local/share/jupyter/hub`. Fixes logo and templates.