### PR TITLE
Reduce dask requests and begin deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![build status](https://travis-ci.org/RhodiumGroup/helm-chart.svg?branch=master)](https://travis-ci.org/RhodiumGroup/helm-chart)
 
+**NOTE:** This repo is in the process of being phased out in favor of https://github.com/RhodiumGroup/daskhub-rhg-config. As of 1/20/21, this repo is being used for minor updates to our `staging` and `impactlab` clusters, while the other repo has incorporated a version bump to the `daskhub` helm-chart that we deploy and is being deployed to the `adrastea` cluster via Argo CD. Once that new deployment approach has been tested, it will be used for all clusters and this repo will be archived.
+
 Helm Charts for Rhodium Group Jupyterhub Deployments
 
 Docker images used in this chart can be found in https://github.com/RhodiumGroup/docker_images

--- a/values.yml
+++ b/values.yml
@@ -188,8 +188,8 @@ dask-gateway:
             # 12/15/20: always using one core unless explicitly defined by 
             # `cpus` due to this issue: https://github.com/dask/dask-gateway/issues/364
             # Can update this behavior if that gets addressed
-            # standard_cores = 1.8
-            standard_mem = 12.7
+            # standard_cores = 1.75
+            standard_mem = 12.25
             scaling_factors = {
                 "micro": 0.5,
                 "standard": 1,


### PR DESCRIPTION
This PR:

- Reduces the memory requests for dask workers b/c "giant" workers were not schedulable, since they were slightly oversized for a node
- Adds a brief explanation in the README about how we will be migrating to a new repo that manages deployments with Argo CD