### PR TITLE
need to reduce worker mem a bit further

### DIFF
--- a/values.yml
+++ b/values.yml
@@ -189,7 +189,7 @@ dask-gateway:
             # `cpus` due to this issue: https://github.com/dask/dask-gateway/issues/364
             # Can update this behavior if that gets addressed
             # standard_cores = 1.75
-            standard_mem = 12.25
+            standard_mem = 11.25
             scaling_factors = {
                 "micro": 0.5,
                 "standard": 1,


### PR DESCRIPTION
Accidentally gave workers 1GB too much still, so could not use giant workers yet. This should fix that